### PR TITLE
Update cores/serv/checks.cfg

### DIFF
--- a/cores/serv/checks.cfg
+++ b/cores/serv/checks.cfg
@@ -25,8 +25,10 @@ read_verilog -sv -defer @basedir@/cores/@core@/serv-src/rtl/wb_gpio.v
 read_verilog -sv -defer @basedir@/cores/@core@/serv-src/rtl/serv_csr.v
 read_verilog -sv -defer @basedir@/cores/@core@/serv-src/rtl/serv_regfile.v
 read_verilog -sv -defer @basedir@/cores/@core@/serv-src/rtl/riscv_timer.v
-read_verilog -sv -defer @basedir@/cores/@core@/serv-src/rtl/ser_eq.v
 read_verilog -sv -defer @basedir@/cores/@core@/serv-src/rtl/ser_lt.v
 read_verilog -sv -defer @basedir@/cores/@core@/serv-src/rtl/ser_shift.v
 read_verilog -sv -defer @basedir@/cores/@core@/serv-src/rtl/shift_reg.v
 read_verilog -sv -defer @basedir@/cores/@core@/serv-src/rtl/serv_alu.v
+read_verilog -sv -defer @basedir@/cores/@core@/serv-src/rtl/serv_bufreg.v
+read_verilog -sv -defer @basedir@/cores/@core@/serv-src/rtl/serv_clock_gen.v
+read_verilog -sv -defer @basedir@/cores/@core@/serv-src/rtl/serv_params.vh


### PR DESCRIPTION
@basedir@/cores/@core@/serv-src/rtl/ser_eq.v no more exists on the https://github.com/olofk/serv repository.

I tried with this suggestion and it PASSED.