### PR TITLE
Add a "mode" option to cfg file

### DIFF
--- a/checks/genchecks.py
+++ b/checks/genchecks.py
@@ -33,6 +33,7 @@ solver = "boolector"
 dumpsmt2 = False
 sbycmd = "sby"
 config = dict()
+mode = "bmc" # bmc/prove/live/cover/equiv/synth
 
 if len(sys.argv) > 1:
     assert len(sys.argv) == 2
@@ -82,6 +83,10 @@ if "options" in config:
         elif line[0] == "dumpsmt2":
             assert len(line) == 1
             dumpsmt2 = True
+        
+        elif line[0] == "mode":
+            assert len(line) == 2
+            mode = line[1]
 
         else:
             print(line)
@@ -119,6 +124,7 @@ hargs["nret"] = nret
 hargs["xlen"] = xlen
 hargs["ilen"] = ilen
 hargs["append"] = 0
+hargs["mode"]= mode
 
 instruction_checks = set()
 consistency_checks = set()
@@ -178,7 +184,7 @@ def check_insn(insn, chanidx, csr_mode=False):
     with open("%s/%s.sby" % (cfgname, check), "w") as sby_file:
         print_hfmt(sby_file, """
                 : [options]
-                : mode bmc
+                : mode @mode@
                 : expect pass,fail
                 : append @append@
                 : tbtop wrapper.uut
@@ -337,7 +343,7 @@ def check_cons(check, chanidx=None, start=None, trig=None, depth=None, csr_mode=
     with open("%s/%s.sby" % (cfgname, check), "w") as sby_file:
         print_hfmt(sby_file, """
                 : [options]
-                : mode bmc
+                : mode @mode@
                 : expect pass,fail
                 : append @append@
                 : tbtop wrapper.uut

--- a/checks/genchecks.py
+++ b/checks/genchecks.py
@@ -446,7 +446,6 @@ for i in range(nret):
     check_cons("unique", chanidx=i, start=0, trig=1, depth=2)
     check_cons("causal", chanidx=i, start=0, depth=1)
     check_cons("ill", chanidx=i, depth=0)
-    check_cons("const_2_time", chanidx=i, start=0, trig=1, depth=2)
 
 check_cons("hang", start=0, depth=1)
 

--- a/checks/rvfi_testbench.sv
+++ b/checks/rvfi_testbench.sv
@@ -13,6 +13,14 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 module rvfi_testbench (
+	`ifdef RISCV_FORMAL_UNBOUNDED
+	`ifdef RISCV_FORMAL_TRIG_CYCLE
+		input trig,
+	`endif
+	`ifdef RISCV_FORMAL_CHECK_CYCLE
+		input check,
+	`endif
+	`endif
 	input clock, reset
 );
 	`RVFI_WIRES
@@ -32,10 +40,18 @@ module rvfi_testbench (
 		.clock  (clock),
 		.reset  (cycle < `RISCV_FORMAL_RESET_CYCLES),
 `ifdef RISCV_FORMAL_TRIG_CYCLE
+`ifdef RISCV_FORMAL_UNBOUNDED
+		.trig   (trig),
+`else
 		.trig   (cycle == `RISCV_FORMAL_TRIG_CYCLE),
 `endif
+`endif
 `ifdef RISCV_FORMAL_CHECK_CYCLE
+`ifdef RISCV_FORMAL_UNBOUNDED
+		.check   (check),
+`else
 		.check  (cycle == `RISCV_FORMAL_CHECK_CYCLE),
+`endif
 `endif
 		`RVFI_CONN
 	);


### PR DESCRIPTION
Add a "mode" option on .cfg file to define whether you are going for a bmc or an induction proof