### PR TITLE
Make basedir overridable, add incdir optional harg

### DIFF
--- a/checks/genchecks.py
+++ b/checks/genchecks.py
@@ -29,6 +29,7 @@ blackbox = False
 
 cfgname = "checks"
 basedir = "%s/../.." % os.getcwd()
+incdir = basedir
 corename = os.getcwd().split("/")[-1]
 solver = "boolector"
 dumpsmt2 = False
@@ -37,8 +38,12 @@ config = dict()
 mode = "bmc"
 
 if len(sys.argv) > 1:
-    assert len(sys.argv) == 2
+    assert 2 <= len(sys.argv) <= 4
     cfgname = sys.argv[1]
+    if len(sys.argv) > 2:
+        basedir = sys.argv[2]
+    if len(sys.argv) > 3:
+        incdir = sys.argv[3]
 
 print("Reading %s.cfg." % cfgname)
 with open("%s.cfg" % cfgname, "r") as f:
@@ -134,6 +139,7 @@ def print_hfmt(f, text, **kwargs):
 
 hargs = dict()
 hargs["basedir"] = basedir
+hargs["incdir"] = incdir
 hargs["core"] = corename
 hargs["nret"] = nret
 hargs["xlen"] = xlen
@@ -333,7 +339,7 @@ def check_insn(grp, insn, chanidx, csr_mode=False):
                     print(line, file=sby_file)
 
 for grp in groups:
-    with open("../../insns/isa_%s.txt" % isa) as isa_file:
+    with open("%s/insns/isa_%s.txt" % (basedir, isa)) as isa_file:
         for insn in isa_file:
             for chanidx in range(nret):
                 check_insn(grp, insn.strip(), chanidx)


### PR DESCRIPTION
During development, it is convenient to integrate formal verification in the build process rather than integrating the core to the verification framework.

This PR removes the restriction to generate and run verification inside the riscv-formal dev tree `cores` directory:
- `genchecks` now accepts an additional argument to override `basedir` (a hard-coded reference to ../.. has been fixed too)
- `genchecks` also provides a extra hargs: `incdir` that can be passed as 3rd command-line argument to define additional include path

In practice, this enables the following:
- `${ROOT_PROJECT}/platform/formal` contains `checks.cfg` and `wrapper.sv`
- `checks.cfg` has a line `read_verilog -sv @incdir@/wrapper.sv`
The following command will create a local, ready-to run directory structure:
```
mkdir -p build/formal&&cd build/formal&&cp ${ROOT_PROJECT}/platform/formal/checks.cfg .
python ${ROOT_RISCV_FORMAL}/checks/genchecks.py checks ${ROOT_RISCV_FORMAL} ${ROOT_PROJECT}/platform/formal
```

NOTE: `genchecks` is assuming `cfgname` is both the filename of the config file and the name of the target directory. This forces the config file to be copied in the build directory instead of just being referenced from the source directory. I couldn't find a way to do that in a backward-compatible way.