### PR TITLE
make explicit the reg_check constant values

### DIFF
--- a/checks/rvfi_reg_check.sv
+++ b/checks/rvfi_reg_check.sv
@@ -16,10 +16,15 @@ module rvfi_reg_check (
 	input clock, reset, check,
 	`RVFI_INPUTS
 );
-	`rvformal_const_rand_reg [63:0] insn_order;
-	`rvformal_const_rand_reg [4:0] register_index;
+	reg [63:0] insn_order;
+	reg [4:0] register_index;
 	reg [`RISCV_FORMAL_XLEN-1:0] register_shadow = 0;
 	reg register_written = 0;
+
+	always @(posedge clock) begin
+		insn_order <= insn_order;
+		register_index <= register_index;
+	end
 
 	integer channel_idx;
 	always @(posedge clock) begin


### PR DESCRIPTION
There are two random constants used in the reg_check, but the verilog code that made them constant were not very reliable.
This PR makes the constness more explicit and uses simple verilog so there shouldn't be any problems with support for "const reg".

On line 12 in https://github.com/SymbioticEDA/riscv-formal/blob/master/checks/rvfi_macros.vh#L12 the definition of "reg" is also not enough to ensure constness. Using "const reg" is not so much better. At least in the tool we are using, this still let the tool produce changing values on that signal. I am not even sure what is legal verilog in this regard, as potentially a constant X value does not have defined formal semantics. Hence I think this simpler solution could be better.

The problem was detected via this issue https://github.com/SymbioticEDA/riscv-formal/issues/53

NB. I have not tested this with picorv32 and symbiyosys.
It is tested with the cv32e40x and a different formal tool, but the 40x currently has a bug that was revealed by this checker.